### PR TITLE
Split up CI jobs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,4 +13,4 @@
       - Milestone
       - Linked Issues
 - [ ] All linter rules passed
-- [ ] Auto-build success (TBA)
+- [ ] Auto-build success

--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -1,0 +1,28 @@
+name: Backend Tests
+
+on:
+  push:
+    branches: [ develop, main ]
+  pull_request:
+    branches: [ develop, main ]
+
+env:
+  MONGO_URI: ${{ secrets.MONGO_URI }}    
+
+jobs:
+
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Install backend dependencies
+      working-directory: ./back-end
+      run: npm install
+
+    - name: Run backend tests
+      working-directory: ./back-end
+      run: npm test

--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -1,4 +1,4 @@
-name: Auto Build
+name: Frontend Tests
 
 on:
   push:
@@ -19,7 +19,8 @@ jobs:
     - name: Install frontend dependencies
       working-directory: ./front-end
       run: npm install
-  
-    - name: Build
-      working-directory: ./front-end
-      run: npm run build
+
+    # TODO: Uncomment once we have frontend tests
+    # - name: Run frontend tests
+    #   working-directory: ./front-end
+    #   run: npm test


### PR DESCRIPTION
## What does this PR do?
- Split up the CI jobs into 3 workflows:
  - Auto build
  - Run frontend tests
  - Run backend tests
- The workflows will now run on both the `develop` branch and the `main` branch

## Checklist before merging
- [x] Applied options on the right:
      - Reviewers
      - Assignee
      - Labels
      - Project
      - Milestone
      - Linked Issues
- [x] All linter rules passed
- [x] Auto-build success
