### PR TITLE
Add new text item to database and display on screen synchronously.

### DIFF
--- a/front-end/src/App.js
+++ b/front-end/src/App.js
@@ -42,6 +42,7 @@ function App() {
   }
 
   useEffect(async () => {
+    let abortController = new AbortController();
     if(isLoading){
       console.log("app is loading");
       return;
@@ -63,7 +64,9 @@ function App() {
     }
 
     getToken({});
-
+    return () => {  
+      abortController.abort();  
+    }; 
   }, [isLoading, isAuthenticated]);
 
   const getToken = (options) => {

--- a/front-end/src/atoms/TextBox.js
+++ b/front-end/src/atoms/TextBox.js
@@ -23,7 +23,6 @@ function TextBox({textItem, onDelete}) {
     onDelete(id);
   };
 
-
   const formatText = (t) => {
     if (t.length > MAX_CHARACTERS) {
       t = t.slice(0, MAX_CHARACTERS-4);

--- a/front-end/src/atoms/TextBox.js
+++ b/front-end/src/atoms/TextBox.js
@@ -7,20 +7,15 @@ import "./TextBox.css";
 
 import axios from "axios";
 
-
 const MAX_CHARACTERS = 142;
 
-
 function TextBox({textItem, onDelete}) {
-  const [ texts, setTexts ] = useState([]);
   const [showTextPopUp, setShowTextPopUp] = useState(false);
 
   const handleDelete = (id) => {
     axios.delete(`${process.env.REACT_APP_BACKEND_SERVER}/texts/${id}`).then(() => {
-      const del = texts.filter(text => id !== text._id);
-      setTexts(del);
+      onDelete(id);
     });
-    onDelete(id);
   };
 
   const formatText = (t) => {

--- a/front-end/src/atoms/TextBoxAdd.js
+++ b/front-end/src/atoms/TextBoxAdd.js
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import PropTypes from "prop-types";
 
 import axios from "axios";
 
@@ -7,10 +8,11 @@ import "./TextBoxAdd.css";
 import "./TextBoxEdit.css";
 
 
-function TextBoxAdd() {
+function TextBoxAdd({onSubmit}) {
 
   const [edit, setEdit] = useState(false);
-  const [textAreaVal, setTextAreaVal] = useState();
+  const [textAreaVal, setTextAreaVal] = useState("");
+  const [textFieldVal, setTextFieldVal] = useState("");
 
   let editCard;
   let addSign;
@@ -18,17 +20,18 @@ function TextBoxAdd() {
 
   const handleOnTextCancel = () => {
     setTextAreaVal("");
+    setTextFieldVal("");
     setEdit(false);
   };
   const handleAddCardClick = () => {
     setEdit(true);
   };
 
-  const handleOnTextSubmit = () => {
+  const handleOnTextSubmit = async () => {
 
     const text = {
       text: textAreaVal,
-      source: "https://www.google.com/webhp?hl=en&sa=X&ved=0ahUKEwjWisuI0qX2AhWpJjQIHbKHBJoQPAgI",
+      source: textFieldVal,
       creationDate: Date.now(),
       updateDate: null,
       deleteDate: null
@@ -37,16 +40,20 @@ function TextBoxAdd() {
     axios
       .post(`${process.env.REACT_APP_BACKEND_SERVER}/texts/add`, text)
       .then((res) => console.log(res.data));
+
+    let result = await axios.get(`${process.env.REACT_APP_BACKEND_SERVER}/texts`);
+    console.log(result?.data);
+    onSubmit(result?.data);
   };
 
-  const handleAddLink = () => {
-    var textfield = document.getElementById("test1");
-    if (textfield.childElementCount == 0) { //Show the textfield 
-      var temp = document.createElement("input");
-      temp.className = "source-field";
-      textfield.appendChild(temp);
-    }
-  };
+  // const handleAddLink = () => {
+  //   var textfield = document.getElementById("test1");
+  //   if (textfield.childElementCount == 0) { //Show the textfield 
+  //     var temp = document.createElement("input");
+  //     temp.className = "source-field";
+  //     textfield.appendChild(temp);
+  //   }
+  // };
 
   editCard= <div className="TextBoxEdit">
     <div className="edit-header" onClick={handleOnTextCancel}>
@@ -71,16 +78,28 @@ function TextBoxAdd() {
     </div>
     <div className="divider"/>
     <div className="edit-footer">
-      <div className="source" target="_blank" rel="noreferrer" onClick={handleAddLink}>
+      {/* <div className="source" target="_blank" rel="noreferrer" onClick={handleAddLink}> */}
+      <div className="source" target="_blank" rel="noreferrer">
         <ChainIcon />
       </div>
-      <div id="test1">        
+      <div id="test1">
+        <input 
+          className="source-field" 
+          type="text" 
+          value = {textFieldVal}
+          onChange={
+            (event)=>{
+              console.log(event.target.value);
+              setTextFieldVal(() =>
+                event.target.value
+              );
+            }
+          }/>        
       </div>
       <div className="send-icon" onClick={handleOnTextSubmit}>
         <PaperPlaneIcon/>
       </div>
     </div>
-
   </div>;
 
 
@@ -98,5 +117,9 @@ function TextBoxAdd() {
     <>{ edit ? editCard : addSign}</>
   );
 }
+
+TextBoxAdd.propTypes = {
+  onSubmit: PropTypes.func.isRequired
+};
 
 export default TextBoxAdd;

--- a/front-end/src/atoms/TextBoxAdd.js
+++ b/front-end/src/atoms/TextBoxAdd.js
@@ -7,31 +7,33 @@ import { AddIcon, PaperPlaneIcon, ExitIcon, ChainIcon } from "./icons";
 import "./TextBoxAdd.css";
 import "./TextBoxEdit.css";
 
-
 function TextBoxAdd({onSubmit}) {
 
   const [edit, setEdit] = useState(false);
   const [textAreaVal, setTextAreaVal] = useState("");
-  const [textFieldVal, setTextFieldVal] = useState("");
+  const [sourceFieldVal, setSourceFieldVal] = useState("");
 
   let editCard;
   let addSign;
 
-
   const handleOnTextCancel = () => {
+    resetValues();
+  };
+
+  const resetValues = () => {
     setTextAreaVal("");
-    setTextFieldVal("");
+    setSourceFieldVal("");
     setEdit(false);
   };
+
   const handleAddCardClick = () => {
     setEdit(true);
   };
 
   const handleOnTextSubmit = async () => {
-
     const text = {
       text: textAreaVal,
-      source: textFieldVal,
+      source: sourceFieldVal,
       creationDate: Date.now(),
       updateDate: null,
       deleteDate: null
@@ -39,21 +41,14 @@ function TextBoxAdd({onSubmit}) {
 
     axios
       .post(`${process.env.REACT_APP_BACKEND_SERVER}/texts/add`, text)
-      .then((res) => console.log(res.data));
+      .then(() => {
+        onSubmit();
+      });
 
-    let result = await axios.get(`${process.env.REACT_APP_BACKEND_SERVER}/texts`);
-    console.log(result?.data);
-    onSubmit(result?.data);
+    setTimeout(() => {
+      resetValues();
+    }, 130);
   };
-
-  // const handleAddLink = () => {
-  //   var textfield = document.getElementById("test1");
-  //   if (textfield.childElementCount == 0) { //Show the textfield 
-  //     var temp = document.createElement("input");
-  //     temp.className = "source-field";
-  //     textfield.appendChild(temp);
-  //   }
-  // };
 
   editCard= <div className="TextBoxEdit">
     <div className="edit-header" onClick={handleOnTextCancel}>
@@ -69,7 +64,6 @@ function TextBoxAdd({onSubmit}) {
         value = {textAreaVal}
         onChange={
           (event)=>{
-            console.log(event.target.value);
             setTextAreaVal(() =>
               event.target.value
             );
@@ -78,19 +72,17 @@ function TextBoxAdd({onSubmit}) {
     </div>
     <div className="divider"/>
     <div className="edit-footer">
-      {/* <div className="source" target="_blank" rel="noreferrer" onClick={handleAddLink}> */}
       <div className="source" target="_blank" rel="noreferrer">
         <ChainIcon />
       </div>
-      <div id="test1">
+      <div id="source">
         <input 
           className="source-field" 
           type="text" 
-          value = {textFieldVal}
+          value = {sourceFieldVal}
           onChange={
             (event)=>{
-              console.log(event.target.value);
-              setTextFieldVal(() =>
+              setSourceFieldVal(() =>
                 event.target.value
               );
             }
@@ -101,8 +93,6 @@ function TextBoxAdd({onSubmit}) {
       </div>
     </div>
   </div>;
-
-
 
   addSign = <div className="TextBoxAdd" onClick={handleAddCardClick}>
     <div className="text-box-add-content">

--- a/front-end/src/molecules/TextList.js
+++ b/front-end/src/molecules/TextList.js
@@ -1,3 +1,4 @@
+/* eslint-disable */
 import React, { useState, useEffect } from "react";
 
 import TextBox from "../atoms/TextBox";
@@ -10,10 +11,18 @@ function TextList() {
   const [ dataIsLoaded, setDataIsLoaded ] = useState(false);
   const [ textItems, setTextItems ] = useState(null);
 
+  const handleSubmit = async (textAdd) => {
+    console.log(textAdd);
+    const newRenderedItem = textAdd;
+    setTextItems(newRenderedItem);
+    console.log(textItems);
+  };
+  
   const handleDelete = (id) => {
     // delete item in JSON based on id
     const newRenderedItem = textItems.filter(text => id !== text._id);
     setTextItems(newRenderedItem);
+    console.log(textItems);
   };
 
   async function getTexts() {
@@ -22,23 +31,27 @@ function TextList() {
   }
 
   useEffect(async () => {
+    let abortController = new AbortController();
     let dbTexts = await getTexts();
     setDataIsLoaded(true);
     if (dataIsLoaded) {
       setTextItems(dbTexts);
     }
+    return () => {  
+      abortController.abort();  
+    } 
   }, [dataIsLoaded]);
 
   const renderList = () => {
-    return textItems && textItems.map( (l) => {
-      return <TextBox key={l._id} textItem={l} onDelete = {(id) => handleDelete(id)}/>;
+    return textItems && textItems.map( (text) => {
+      return <TextBox key={text._id} textItem={text} onDelete = {(id) => handleDelete(id)}/>;
     });
   };
 
   return (
     <div className= "text-list">
       {renderList()}
-      {<TextBoxAdd showInput={false}/>}
+      {<TextBoxAdd showInput={false} onSubmit = {(textAdd) => handleSubmit(textAdd)}/>}
     </div>
   );
 }

--- a/front-end/src/molecules/TextList.js
+++ b/front-end/src/molecules/TextList.js
@@ -11,18 +11,15 @@ function TextList() {
   const [ dataIsLoaded, setDataIsLoaded ] = useState(false);
   const [ textItems, setTextItems ] = useState(null);
 
-  const handleSubmit = async (textAdd) => {
-    console.log(textAdd);
-    const newRenderedItem = textAdd;
-    setTextItems(newRenderedItem);
-    console.log(textItems);
+  const handleSubmit = async () => {
+    let newTextItems = await getTexts();
+    setTextItems(newTextItems);
   };
   
   const handleDelete = (id) => {
     // delete item in JSON based on id
     const newRenderedItem = textItems.filter(text => id !== text._id);
     setTextItems(newRenderedItem);
-    console.log(textItems);
   };
 
   async function getTexts() {
@@ -51,7 +48,7 @@ function TextList() {
   return (
     <div className= "text-list">
       {renderList()}
-      {<TextBoxAdd showInput={false} onSubmit = {(textAdd) => handleSubmit(textAdd)}/>}
+      {<TextBoxAdd showInput={false} onSubmit = {() => handleSubmit()}/>}
     </div>
   );
 }


### PR DESCRIPTION
## What does this PR do?
- should be able to add to the database now using the web app
- add a new text item should display the new textbox right away (for the most part)

### Steps to test/review (optional)
- do usual runs for front-end and back-end: `npm start`
- input some text and a valid link to the textbox-add-component then press the add button
- check both the web app display and the mongo database to see if the new text item was registered

## Checklist before merging
- [x] Applied options on the right:
      - Reviewers
      - Assignee
      - Labels
      - Project
      - Milestone
      - Linked Issues
- [x] All linter rules passed
- [x] Auto-build success (TBA)
