### PR TITLE
Copy link in Popup

### DIFF
--- a/front-end/src/atoms/TextBoxPopUp.js
+++ b/front-end/src/atoms/TextBoxPopUp.js
@@ -21,7 +21,15 @@ function TextBoxPopUp( {text, source, onChangeVisibility} ) {
   };
 
   const handleOnSourceClick = () => {
-    alert("Temporary: Link Clicked");
+    alert(`Link copied: ${source}`);
+
+    //Create a temporary element to be able to copy the source
+    var temp = document.createElement("textarea");
+    temp.value = source;
+    document.body.appendChild(temp);
+    temp.select();
+    document.execCommand("copy");
+    document.body.removeChild(temp);
   };
 
   const renderSource = (srcText) => {
@@ -39,7 +47,7 @@ function TextBoxPopUp( {text, source, onChangeVisibility} ) {
             <ChainIconSmallIcon/>
           </div>
           <div className="TextBoxPopUp-source-text">
-            <a className="TextBoxPopUp-source-text-a"href={source}>{renderSource(source)}</a>
+            <a className="TextBoxPopUp-source-text-a">{renderSource(source)}</a>
           </div>
         </div>
         <div className="TextBoxPopUp-text">


### PR DESCRIPTION
## What does this PR do?

Clicking the link in a popup now copies the link instead of taking you directly to the source.

### Screenshots (optional)

### Steps to test/review (optional)

- Click on any one of the current cards
- Click on the link/chain icon on the popup
- Paste link into new tab

## Checklist before merging
- [x] Applied options on the right:
      - Reviewers
      - Assignee
      - Labels
      - Project
      - Milestone
      - Linked Issues
- [x] All linter rules passed
- [x] Auto-build success
