### PR TITLE
Added tests for Texts endpoints and schema

### DIFF
--- a/back-end/__tests__/accounts.test.js
+++ b/back-end/__tests__/accounts.test.js
@@ -34,7 +34,7 @@ describe("Accounts Router Tests", () => {
 			
 			// Remove test data from DB
 			await Account.findOneAndDelete({auth0Id: testAccount.auth0Id});
-		})
+		});
 
 		test("Get an account that does not exist.", async () => {
 			await request(app).get("/accounts/auth0/foo")
@@ -43,7 +43,7 @@ describe("Accounts Router Tests", () => {
 					expect(res.statusCode).toEqual(200);
 					expect(res.body).toEqual([]);
 				});
-		})
+		});
 	});
 
 	describe("POST /accounts/add", () => {
@@ -60,7 +60,7 @@ describe("Accounts Router Tests", () => {
 			await Account.findOneAndDelete({auth0Id: testAccount.auth0Id});
     	});
 
-		test("Add an invalid account to the database", async () => {
+		test("Add an invalid account to the database.", async () => {
 			await request(app).post("/accounts/add")
 				.send(invalidAccount)
 				.then((res) => {
@@ -70,7 +70,7 @@ describe("Accounts Router Tests", () => {
   	});
 
 	describe("Account schema validation", () => {
-		test("Add an account that meets all schema requirements", async () => {
+		test("Add an account that meets all schema requirements.", async () => {
 			await Account.create(testAccount)
 				.then((res) => {
 					expect(res).toBeTruthy();
@@ -78,14 +78,14 @@ describe("Accounts Router Tests", () => {
 			
 			// Remove test data from DB
 			await Account.findOneAndDelete({auth0Id: testAccount.auth0Id});
-		})
+		});
 
-		test("Add an account that is missing a required attribute", async () => {
+		test("Add an account that is missing a required attribute.", async () => {
 			await Account.create(invalidAccount)
 				.catch((err) => {
 					expect(err).toBeTruthy();
 					expect(err.message).toEqual("Account validation failed: email: Path `email` is required.");
 				});
-		})
+		});
 	});
 });

--- a/back-end/__tests__/texts.test.js
+++ b/back-end/__tests__/texts.test.js
@@ -1,0 +1,101 @@
+const app = require("../server");
+const request = require("supertest");
+const Text = require("../persistence/models/texts.model");
+const mongoose = require("mongoose");
+
+const testId = mongoose.Types.ObjectId("123456781234567812345678");
+
+const testText = {
+    _id: testId,
+    text: "This is a test -NN",
+    source: "www.abc.com",
+};
+
+const invalidText = {
+    source: "www.google.com",
+};
+
+describe("Texts Router Tests", () => {
+	describe("GET /texts/", () => {
+		test("Get all of the texts in the database.", async () => {
+			await request(app).get("/texts")
+				.expect(200)
+				.then((res) => {
+					expect(res.statusCode).toEqual(200);
+					expect(res.body).toBeTruthy();
+				});
+		});
+	});
+
+	describe("POST /texts/add", () => {
+    	test("Add a valid text to the database.", async () => {
+			await request(app).post("/texts/add")
+				.send(testText)
+				.expect(200)
+				.then((res) => {
+					expect(res.statusCode).toEqual(200);
+					expect(res.body).toEqual("Text added!");
+				});
+
+			// Remove test data from DB
+			await Text.findOneAndDelete({
+                text: testText.text,
+                source: testText.source
+            });
+    	});
+
+		test("Add an invalid text to the database.", async () => {
+			await request(app).post("/texts/add")
+				.send(invalidText)
+				.then((res) => {
+					expect(res.statusCode).toEqual(400);
+				});
+    	});
+  	});
+
+    describe("DELETE /texts/:id", () => {
+    	test("Delete an existing text from the database.", async () => {
+            let reqId = "123456781234567812345678";
+
+            await Text.create(testText);
+
+			await request(app).delete("/texts/" + reqId)
+				.expect(200)
+				.then((res) => {
+					expect(res.statusCode).toEqual(200);
+					expect(res.body).toEqual("Text Deleted.");
+				});
+
+			// Remove test data from DB
+            let deletedItem = await Text.findById(testId);
+            expect(deletedItem).toEqual(null);
+    	});
+
+		test("Delete an invalid text to the database.", async () => {
+			await request(app).delete("/texts/123")
+				.then((res) => {
+					expect(res.statusCode).toEqual(400);
+				});
+    	});
+  	});
+
+	describe("Text schema validation", () => {
+		test("Add a text that meets all schema requirements.", async () => {
+			await Text.create(testText)
+				.then((res) => {
+					expect(res).toBeTruthy();
+				});
+			
+			// Remove test data from DB
+            await Text.findByIdAndDelete(testId);
+		})
+
+		test("Add a text that is missing a required attribute.", async () => {
+			await Text.create(invalidText)
+				.catch((err) => {
+					expect(err).toBeTruthy();
+					expect(err.message).toEqual("Text validation failed: text: Path `text` is required.");
+				});
+		})
+	});
+});

--- a/back-end/persistence/texts.js
+++ b/back-end/persistence/texts.js
@@ -8,7 +8,6 @@ router.route("/").get((req, res) => {
 });
 
 router.route("/add").post((req, res) => {
-	// const name = req.body.name;
 	const text = req.body.text;
 	const source = req.body.source;
 	const creationDate = req.body.creationDate;

--- a/back-end/server.js
+++ b/back-end/server.js
@@ -30,8 +30,10 @@ app.use("/workspaces", workspacesRouter);
 app.use("/texts", textsRouter);
 app.use("/accounts", accountsRouter);
 
-app.listen(port, () => {
-	console.log(`Server is running on port: ${port}`);
-});
+if (process.env.NODE_ENV !== "test") {
+	app.listen(port, () => {
+		console.log(`Server is running on port: ${port}`);
+	});
+}
 
 module.exports = app;


### PR DESCRIPTION
## What does this PR do?
- Added backend tests for a `Texts` object
- Disabled making the server listen to a port if we're only running tests
  - changes in `server.js`

### Steps to test/review
1. `cd back-end`
2. `npm install` if needed
3. `npm test`
4. All tests should pass!

## Checklist before merging
- [x] Applied options on the right:
      - Reviewers
      - Assignee
      - Labels
      - Project
      - Milestone
      - Linked Issues
- [x] All linter rules passed
- [x] Auto-build success
