### PR TITLE
Fixed bug with web app and uninstalled extension

### DIFF
--- a/front-end/src/App.js
+++ b/front-end/src/App.js
@@ -34,9 +34,11 @@ function App() {
       let userId = user.sub;
       let auth0Id = userId.replace("|", "-");	// Must replace "|" to allow for GET query
 
-      // send auth0Id to web extension
-      window.localStorage.setItem("auth0Id", auth0Id);
-      chrome.runtime.sendMessage(`${process.env.REACT_APP_EXTENSION_ID}`, { messageFromWeb: window.localStorage });
+      if (chrome.runtime !== undefined) {
+        // send auth0Id to web extension
+        window.localStorage.setItem("auth0Id", auth0Id);
+        chrome.runtime.sendMessage(`${process.env.REACT_APP_EXTENSION_ID}`, { messageFromWeb: window.localStorage });
+      }
 
       let account = await getAccount(auth0Id);
 


### PR DESCRIPTION
## What does this PR do?
- previously, there would be errors in front-end where web app would crash if extension is not installed in chrome
- fixed that bug so front-end can still run without crashing when extension is not installed

### Screenshots (optional)

### Steps to test/review (optional)
- try running front-end without the extension being installed (should run normally)
- try again when extension is installed

## Checklist before merging
- [x] Applied options on the right:
      - Reviewers
      - Assignee
      - Labels
      - Project
      - Milestone
      - Linked Issues
- [x] All linter rules passed
- [x] Auto-build success
