### PR TITLE
Add Propagation of Props Refactor

### DIFF
--- a/front-end/src/atoms/icons.js
+++ b/front-end/src/atoms/icons.js
@@ -9,8 +9,8 @@ export function AddCollabIcon(props) {
   return <img alt="add collaborator" src="/assets/images/add-collab.svg" className="icon" {...props}/>;
 }
 
-export function BookMarkIcon() {
-  return <img alt="bookmark" src="/assets/images/bookmark.svg" className="icon"/>;
+export function BookMarkIcon(props) {
+  return <img alt="bookmark" src="/assets/images/bookmark.svg" className="icon" {...props}/>;
 }
 
 export function ChainIconSmallIcon(props) {
@@ -21,28 +21,28 @@ export function ChainIcon(props) {
   return <img alt="link" src="/assets/images/chain.svg" className="icon" {...props}/>;
 }
 
-export function LogoutIcon() {
-  return <img alt="logout" src="/assets/images/logout.svg" className="icon"/>;
+export function LogoutIcon(props) {
+  return <img alt="logout" src="/assets/images/logout.svg" className="icon" {...props}/>;
 }
 
 export function GearIcon(props) {
   return <img alt="gear" src="/assets/images/gear.svg" className="icon" {...props}/>;
 }
 
-export function GearSmallIcon() {
-  return <img alt="gear" src="/assets/images/gear_sm.svg" className="icon"/>;
+export function GearSmallIcon(props) {
+  return <img alt="gear" src="/assets/images/gear_sm.svg" className="icon" {...props}/>;
 }
 
-export function GearSmallGreyIcon() {
-  return <img alt="gear" src="/assets/images/gear_sm_grey.svg" className="icon"/>;
+export function GearSmallGreyIcon(props) {
+  return <img alt="gear" src="/assets/images/gear_sm_grey.svg" className="icon" {...props}/>;
 }
 
 export function ExitIcon(props) {
   return <img alt="cross" src="/assets/images/delete.svg" className="icon-delete" {...props}/>;
 }
 
-export function DragVerticalIcon() {
-  return <img alt="drag vertical" src="/assets/images/drag_vertical.svg" className="icon"/>;
+export function DragVerticalIcon(props) {
+  return <img alt="drag vertical" src="/assets/images/drag_vertical.svg" className="icon" {...props}/>;
 }
 
 export function EditIcon(props) {
@@ -53,20 +53,20 @@ export function SaveIcon(props) {
   return <img alt="save" src="/assets/images/save.svg" className="icon" {...props}/>;
 }
 
-export function ShareIcon() {
-  return <img alt="share" src="/assets/images/share.svg" className="icon"/>;
+export function ShareIcon(props) {
+  return <img alt="share" src="/assets/images/share.svg" className="icon" {...props}/>;
 }
 
 export function TrashCanIcon(props) {
   return <img alt="trash can" src="/assets/images/trash_can.svg" className="icon" {...props}/>;
 }
 
-export function AddIcon() {
-  return <img alt="add" src="/assets/images/add.svg" className="icon"/>;
+export function AddIcon(props) {
+  return <img alt="add" src="/assets/images/add.svg" className="icon" {...props}/>;
 }
 
-export function PaperPlaneIcon() {
-  return <img alt="send" src="/assets/images/paper_plane.svg" className="icon"/>;
+export function PaperPlaneIcon(props) {
+  return <img alt="send" src="/assets/images/paper_plane.svg" className="icon" {...props}/>;
 }
 
 export function LogoIcon(props) {


### PR DESCRIPTION
## What does this PR do?

Before our icon components did not accept props **making it hard to apply custom styling to them**. Now, we  have prop propagation for each one of them, which will make it easier!

To test:
- run front end
- there shouldn't be any changes with styling and styling issues.
- see code diff to make sure I didn't miss anyhting.

## Checklist before merging
- [x] Applied options on the right:
      - Reviewers
      - Assignee
      - Labels
      - Project
      - Milestone
      - Linked Issues
- [x] All linter rules passed
- [x] Auto-build success
