### PR TITLE
Fixed text overflow when workspace has a long name

### DIFF
--- a/front-end/src/organisms/WorkspaceSettings.css
+++ b/front-end/src/organisms/WorkspaceSettings.css
@@ -29,6 +29,8 @@
     justify-content: space-between;
     align-items: center;
     align-self: center;
+
+    overflow: auto;
 }
 
 .WorkspaceSettings-top{
@@ -46,9 +48,14 @@
     padding-right: 30px;
 }
 
+.WorkspaceSettings-header {
+    width: 70%;
+}
+
 .WorkspaceSettings-header-text{
     display: flex;
     flex-direction: row;
+    justify-content: center;
 }
 
 .WorkspaceSettings-header-text-title{
@@ -56,6 +63,8 @@
     font-size: 36px;
     text-align: center;
     margin-bottom: 10px;
+    overflow: auto;
+    word-wrap: break-word;
 }
 
 .WorkspaceSettings-header-edit {
@@ -68,7 +77,7 @@
     font-size: 36px;
     border-style: hidden;
     outline: none;
-    width: 60%;
+    width: 100%;
 }
 
 .WorkspaceSettings-header-edit-icon,


### PR DESCRIPTION
## What does this PR do?
- Fixed overflow on WorkspaceSettings when the workspace has a long name

### Screenshots
Before:
![image](https://user-images.githubusercontent.com/44079021/163732811-31d982e0-f531-4b83-92e6-259f52eeb353.png)

After:
![image](https://user-images.githubusercontent.com/44079021/163732778-173d3ada-6a67-4a55-9f69-58f0044c07ce.png)

### Steps to test/review
- Adding a new workspace with a long name shouldn't overflow in the settings

## Checklist before merging
- [x] Applied options on the right:
      - Reviewers
      - Assignee
      - Labels
      - Project
      - Milestone
      - Linked Issues
- [x] All linter rules passed
- [x] Auto-build success
